### PR TITLE
Allow skipping of codechecker installation for environments with pre-existing tools

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
     default: 'Ericsson/CodeChecker'
   version:
-    description: 'The version of the CodeChecker suite to obtain and execute. Might be a Git commit SHA, a branch name, or a tag if building a custom package, or a release version if downloading from PyPI. If "master" and downloading from PyPI, fetch the latest release.'
+    description: 'The version of the CodeChecker suite to obtain and execute. Might be a Git commit SHA, a branch name, or a tag if building a custom package, or a release version if downloading from PyPI. If "master" and downloading from PyPI, fetch the latest release. If "skip", assume CodeChecker is already installed and available in PATH (useful for Docker containers with pre-installed tools).'
     required: true
     default: 'master'
   llvm-version:

--- a/action.yml
+++ b/action.yml
@@ -15,7 +15,7 @@ inputs:
     required: true
     default: 'Ericsson/CodeChecker'
   version:
-    description: 'The version of the CodeChecker suite to obtain and execute. Might be a Git commit SHA, a branch name, or a tag if building a custom package, or a release version if downloading from PyPI. If "master" and downloading from PyPI, fetch the latest release. If "skip", assume CodeChecker is already installed and available in PATH (useful for Docker containers with pre-installed tools).'
+    description: 'The version of the CodeChecker suite to obtain and execute. Might be a Git commit SHA, a branch name, or a tag if building a custom package, or a release version if downloading from PyPI. If "master" and downloading from PyPI, fetch the latest release. If "ignore", assume CodeChecker is already installed and available in PATH (useful for Docker containers with pre-installed tools).'
     required: true
     default: 'master'
   llvm-version:

--- a/src/pip-codechecker.sh
+++ b/src/pip-codechecker.sh
@@ -5,11 +5,11 @@ if [[ ! -z "$CODECHECKER_ACTION_DEBUG" ]]; then
 fi
 
 # Check if CodeChecker is already installed and skip installation if requested
-if [[ "$IN_VERSION" == "skip" ]]; then
-  echo "::group::Using pre-installed CodeChecker (skip requested)"
+if [[ "$IN_VERSION" == "ignore" ]]; then
+  echo "::group::Using pre-installed CodeChecker (ignore requested)"
   if ! command -v CodeChecker &> /dev/null; then
-    echo "::error::CodeChecker not found in PATH but version='skip' was specified"
-    echo "Please ensure CodeChecker is installed before running this action with version='skip'"
+    echo "::error::CodeChecker not found in PATH but version='ignore' was specified"
+    echo "Please ensure CodeChecker is installed before running this action with version='ignore'"
     exit 1
   fi
   echo "CodeChecker found at: $(which CodeChecker)"

--- a/src/pip-codechecker.sh
+++ b/src/pip-codechecker.sh
@@ -4,35 +4,47 @@ if [[ ! -z "$CODECHECKER_ACTION_DEBUG" ]]; then
   set -x
 fi
 
-echo "::group::Installing CodeChecker $IN_VERSION from PyPI"
-if [[ "$IN_VERSION" == "master" ]]; then
-  # The default branch name "master" is offered as a convenient shortcut for
-  # fetching the latest release. Unfortunately, this might just be a release
-  # candidate, which we do not wish to supply to automated production users
-  # this eagerly...
+# Check if CodeChecker is already installed and skip installation if requested
+if [[ "$IN_VERSION" == "skip" ]]; then
+  echo "::group::Using pre-installed CodeChecker (skip requested)"
+  if ! command -v CodeChecker &> /dev/null; then
+    echo "::error::CodeChecker not found in PATH but version='skip' was specified"
+    echo "Please ensure CodeChecker is installed before running this action with version='skip'"
+    exit 1
+  fi
+  echo "CodeChecker found at: $(which CodeChecker)"
+  echo "::endgroup::"
+else
+  echo "::group::Installing CodeChecker $IN_VERSION from PyPI"
+  if [[ "$IN_VERSION" == "master" ]]; then
+    # The default branch name "master" is offered as a convenient shortcut for
+    # fetching the latest release. Unfortunately, this might just be a release
+    # candidate, which we do not wish to supply to automated production users
+    # this eagerly...
 
-  # Hack to get pip list us which versions are available...
-  # (thanks, http://stackoverflow.com/a/26664162)
-  pip3 install codechecker=="You_cant_be_serious_mate" 2>&1  \
-    | grep "ERROR: Could not find a version"                 \
-    | sed 's/^.*(from versions: \(.*\))/\1/'                 \
-    | sed 's/, /\n/g'                                        \
-    | grep -v 'rc\|a'                                        \
-    | sort -V                                                \
-    | tail -n 1                                              \
-    >> "codechecker_latest_release.txt"
+    # Hack to get pip list us which versions are available...
+    # (thanks, http://stackoverflow.com/a/26664162)
+    pip3 install codechecker=="You_cant_be_serious_mate" 2>&1  \
+      | grep "ERROR: Could not find a version"                 \
+      | sed 's/^.*(from versions: \(.*\))/\1/'                 \
+      | sed 's/, /\n/g'                                        \
+      | grep -v 'rc\|a'                                        \
+      | sort -V                                                \
+      | tail -n 1                                              \
+      >> "codechecker_latest_release.txt"
 
-  IN_VERSION=$(cat "codechecker_latest_release.txt")
-  echo "Selected CodeChecker version $IN_VERSION automatically."
-  rm "codechecker_latest_release.txt"
+    IN_VERSION=$(cat "codechecker_latest_release.txt")
+    echo "Selected CodeChecker version $IN_VERSION automatically."
+    rm "codechecker_latest_release.txt"
+  fi
+
+  set -e
+
+  pip3 install codechecker=="$IN_VERSION"
+
+  pip3 show codechecker
+  echo "::endgroup::"
 fi
-
-set -e
-
-pip3 install codechecker=="$IN_VERSION"
-
-pip3 show codechecker
-echo "::endgroup::"
 
 which CodeChecker
 CodeChecker analyzer-version


### PR DESCRIPTION
If the workflow requires a container with pre-existing tools, might as well allow usage of preexisting codechecker install.