### PR TITLE
Fix running on custom containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ runs:
         store-username: ${{ secrets.CODECHECKER_STORE_USER }}
         store-password: ${{ secrets.CODECHECKER_STORE_PASSWORD }}
         # Keep the names for 'store' and 'diff' in sync, or auto-generated!
-        # diff-run-name: "custom run name to store with"
+        # store-run-name: "custom run name to store with"
 
         diff: ${{ github.event_name == 'pull_request' }}
         diff-url: 'http://example.com:8001/MyProject'

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ job:
         cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
 
     # Run the analysis
-    - uses: whisperity/codechecker-analysis-action@v1
+    - uses: whisperity/codechecker-action@v1
       id: codechecker
       with:
         logfile: ${{ github.workspace }}/Build/compile_commands.json
@@ -89,7 +89,7 @@ job:
         cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
 
     # Run the analysis
-    - uses: whisperity/codechecker-analysis-action@v1
+    - uses: whisperity/codechecker-action@v1
       id: codechecker
       with:
         build-command: "cd ${{ github.workspace }}/Build; cmake --build ."
@@ -124,7 +124,7 @@ job:
         cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
 
     # Run the analysis
-    - uses: whisperity/codechecker-analysis-action@v1
+    - uses: whisperity/codechecker-action@v1
       id: codechecker
       with:
         build-command: "cd ${{ github.workspace }}/Build; cmake --build ."
@@ -166,7 +166,7 @@ job:
         cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
 
     # Run the analysis
-    - uses: whisperity/codechecker-analysis-action@v1
+    - uses: whisperity/codechecker-action@v1
       id: codechecker
       with:
         build-command: "cd ${{ github.workspace }}/Build; cmake --build ."
@@ -204,7 +204,7 @@ runs:
         cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=OFF
 
     # Run the analysis
-    - uses: whisperity/codechecker-analysis-action@v1
+    - uses: whisperity/codechecker-action@v1
       id: codechecker
       with:
         build-command: "cd ${{ github.workspace }}/Build; cmake --build ."
@@ -272,7 +272,7 @@ job:
         pylint -f json --exit-zero myproject > pylint_reports.json
 
     # Run the conversion
-    - uses: whisperity/codechecker-analysis-action@v1
+    - uses: whisperity/codechecker-action@v1
       id: codechecker
       with:
         report-converter: true

--- a/action.yml
+++ b/action.yml
@@ -10,6 +10,7 @@ inputs:
     description: 'Whether to download, check out, and build a CodeChecker package manually in the CI.'
     required: true
     default: 'false'
+    type: boolean
   repository:
     description: 'The CodeChecker repository to check out and build from.'
     required: true
@@ -42,10 +43,12 @@ inputs:
     description: 'Whether to enable Cross Translation Unit (CTU) analysis in the Clang Static Analyzer.'
     required: true
     default: 'false'
+    type: boolean
   ignore-analyze-crashes:
     description: 'If set to "true", the "analyze" action will ALWAYS pass, and not report a failure if some analysis jobs fail to execute due to internal crashes in the Clang analysers.'
     required: true
     default: 'true'
+    type: boolean
   analyzer-config:
     description: "Same as CodeChecker's `--analyzer-config`. E.g.: `cppcheck:cc-verbatim-args-file=cppcheck_args.txt`"
     required: false
@@ -68,6 +71,7 @@ inputs:
     description: 'Whether to enable calculating the different of the current analysis results against a run stored on a CodeChecker server. If enabled, other flags, such as "diff-url" must also be set.'
     required: true
     default: 'false'
+    type: boolean
   diff-url:
     description: 'The CodeChecker product URL (usually in the format of http://example.com/ProductName) where the diff should connect to. Mandatory if "diff" is true.'
     required: false
@@ -86,6 +90,7 @@ inputs:
     description: 'Whether to enable storing the results to a CodeChecker server. If enabled, other flags, such as "store-url" must also be set.'
     required: true
     default: 'false'
+    type: boolean
   store-url:
     description: 'The CodeChecker product URL (usually in the format of http://example.com/ProductName) where the store should connect to. Mandatory if "store" is true.'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -160,7 +160,7 @@ runs:
       env:
         IN_LLVM_VERSION: ${{ inputs.llvm-version }}
       shell: bash
-      run: ${{ github.action_path }}/src/get-llvm.sh
+      run: ${GITHUB_ACTION_PATH}/src/get-llvm.sh
 
     - name: "Build and Package CodeChecker"
       id: codechecker
@@ -177,9 +177,9 @@ runs:
         fi
 
         if [[ "$IN_INSTALL_CUSTOM" == "true" ]]; then
-          ${{ github.action_path }}/src/build-codechecker.sh
+          ${GITHUB_ACTION_PATH}/src/build-codechecker.sh
         else
-          ${{ github.action_path }}/src/pip-codechecker.sh
+          ${GITHUB_ACTION_PATH}/src/pip-codechecker.sh
         fi
 
     - name: "Prepare JSON Compilation Database"
@@ -194,7 +194,7 @@ runs:
 
         OUT_FILE: ${{ github.workspace }}/${{ github.action }}_codechecker_compilation_database.json
       shell: bash
-      run: ${{ github.action_path }}/src/get-or-create-build-json.sh
+      run: ${GITHUB_ACTION_PATH}/src/get-or-create-build-json.sh
 
     - name: "Execute static analysis for C/C++"
       id: analyze
@@ -209,7 +209,7 @@ runs:
         IN_IGNORE_CRASHES: ${{ inputs.ignore-analyze-crashes }}
         IN_OUTPUT_DIR: ${{ inputs.analyze-output }}
       shell: bash
-      run: ${{ github.action_path }}/src/execute-analysis.sh
+      run: ${GITHUB_ACTION_PATH}/src/execute-analysis.sh
 
     - name: "Perform report-converter"
       id: report-convert
@@ -223,7 +223,7 @@ runs:
         IN_IGNORE_CRASHES: ${{ inputs.ignore-analyze-crashes }}
         IN_OUTPUT_DIR: ${{ inputs.analyze-output }}
       shell: bash
-      run: ${{ github.action_path }}/src/report-converter.sh
+      run: ${GITHUB_ACTION_PATH}/src/report-converter.sh
 
     # This step is needed because it is forbidden to reuse the 'id' of a step,
     # even if the two steps taking the same 'id' are mutually exclusive.
@@ -254,7 +254,7 @@ runs:
 
         IN_CONFIGFILE: ${{ inputs.config }}
       shell: bash
-      run: ${{ github.action_path }}/src/parse-results.sh
+      run: ${GITHUB_ACTION_PATH}/src/parse-results.sh
 
     - name: "Generate the configuration for diffing current results against previously stored"
       id: diff-pre
@@ -271,7 +271,7 @@ runs:
         GITHUB_REF_NAME: ${{ github.ref_name }}
         GITHUB_REF_TYPE: ${{ github.ref_type }}
       shell: bash
-      run: ${{ github.action_path }}/src/diff-pre.sh
+      run: ${GITHUB_ACTION_PATH}/src/diff-pre.sh
 
     - name: "Diff current results against previously stored run"
       id: diff
@@ -285,7 +285,7 @@ runs:
         IN_CONFIGFILE: ${{ inputs.config }}
         IN_DIFF_URL: ${{ inputs.diff-url }}
       shell: bash
-      run: ${{ github.action_path }}/src/diff.sh
+      run: ${GITHUB_ACTION_PATH}/src/diff.sh
 
     - name: "Generate the configuration for uploading results"
       id: store-pre
@@ -301,7 +301,7 @@ runs:
         GITHUB_REF_TYPE: ${{ github.ref_type }}
         GITHUB_SHA: ${{ github.sha }}
       shell: bash
-      run: ${{ github.action_path }}/src/store-pre.sh
+      run: ${GITHUB_ACTION_PATH}/src/store-pre.sh
 
     - name: "Store analysis results to server"
       id: store
@@ -316,4 +316,4 @@ runs:
         IN_CONFIGFILE: ${{ inputs.config }}
         IN_STORE_URL: ${{ inputs.store-url }}
       shell: bash
-      run: ${{ github.action_path }}/src/store.sh
+      run: ${GITHUB_ACTION_PATH}/src/store.sh

--- a/action.yml
+++ b/action.yml
@@ -46,6 +46,9 @@ inputs:
     description: 'If set to "true", the "analyze" action will ALWAYS pass, and not report a failure if some analysis jobs fail to execute due to internal crashes in the Clang analysers.'
     required: true
     default: 'true'
+  analyzer-config:
+    description: "Same as CodeChecker's `--analyzer-config`. E.g.: `cppcheck:cc-verbatim-args-file=cppcheck_args.txt`"
+    required: false
 
   report-converter:
     description: 'Whether to perform report conversion from analyses executed by third-party analysers instead of driving the analysis via CodeChecker directly.'
@@ -206,6 +209,7 @@ runs:
 
         IN_CONFIGFILE: ${{ inputs.config }}
         IN_CTU: ${{ inputs.ctu }}
+        IN_ANALYZER_CONFIG: ${{ inputs.analyzer-config }}
         IN_IGNORE_CRASHES: ${{ inputs.ignore-analyze-crashes }}
         IN_OUTPUT_DIR: ${{ inputs.analyze-output }}
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -49,6 +49,9 @@ inputs:
   analyzer-config:
     description: "Same as CodeChecker's `--analyzer-config`. E.g.: `cppcheck:cc-verbatim-args-file=cppcheck_args.txt`"
     required: false
+  skipfile:
+    description: "A file contianing which files to skip during analysis. Same as CodeChecker's `--skipfile` argument."
+    required: false
 
   report-converter:
     description: 'Whether to perform report conversion from analyses executed by third-party analysers instead of driving the analysis via CodeChecker directly.'
@@ -210,6 +213,7 @@ runs:
         IN_CONFIGFILE: ${{ inputs.config }}
         IN_CTU: ${{ inputs.ctu }}
         IN_ANALYZER_CONFIG: ${{ inputs.analyzer-config }}
+        IN_SKIPFILE: ${{ inputs.skipfile }}
         IN_IGNORE_CRASHES: ${{ inputs.ignore-analyze-crashes }}
         IN_OUTPUT_DIR: ${{ inputs.analyze-output }}
       shell: bash

--- a/src/diff-pre.sh
+++ b/src/diff-pre.sh
@@ -10,7 +10,7 @@ fi
 
 if [[ ! -z "$IN_DIFF_USERNAME" && ! -z "$IN_DIFF_PASSWORD" ]]; then
   echo "Configuring credentials..."
-  cat <<EOF > ~/.codechecker.passwords.json
+  cat <<EOF > /.codechecker.passwords.json
     {
       "client_autologin": true,
       "credentials": {
@@ -18,7 +18,7 @@ if [[ ! -z "$IN_DIFF_USERNAME" && ! -z "$IN_DIFF_PASSWORD" ]]; then
       }
     }
 EOF
-  chmod 0600 ~/.codechecker.passwords.json
+  chmod 0600 /.codechecker.passwords.json
 fi
 
 if [[ ! -z "$IN_DIFF_RUN_NAME" && "$IN_DIFF_RUN_NAME" != "__DEFAULT__" ]]; then

--- a/src/diff.sh
+++ b/src/diff.sh
@@ -28,6 +28,7 @@ fi
 OUTPUT_DIR="$RAW_RESULT_DIR"_DiffHTML
 OUTPUT_LOG="$(dirname "$RAW_RESULT_DIR")"/"$(basename "$RAW_RESULT_DIR")_Diff.log"
 mkdir -pv "$(dirname "$OUTPUT_DIR")"
+export CC_PASS_FILE=/.codechecker.passwords.json
 echo "::endgroup::"
 
 echo "::group::Generating HTML results from diff"

--- a/src/execute-analysis.sh
+++ b/src/execute-analysis.sh
@@ -26,6 +26,12 @@ if [[ "$IN_CTU" == "true" ]]; then
   CTU_FLAGS="--ctu --ctu-ast-mode load-from-pch"
   echo "::notice title=Cross Translation Unit analyis::CTU has been enabled, the analysis might take a long time!"
 fi
+
+if [[ ! -z "$IN_ANALYZER_CONFIG" ]]; then
+  ANALYZER_CONFIG_FLAG_1="--analyzer-config"
+  ANALYZER_CONFIG_FLAG_2=$IN_ANALYZER_CONFIG
+  echo "Using analyzer-config: \"$IN_ANALYZER_CONFIG\"!"
+fi
 echo "::endgroup::"
 
 "$CODECHECKER_PATH"/CodeChecker analyzers \
@@ -38,7 +44,8 @@ echo "::group::Executing Static Analysis"
     --output "$OUTPUT_DIR" \
     --jobs $(nproc) \
     $CONFIG_FLAG_1 $CONFIG_FLAG_2 \
-    $CTU_FLAGS
+    $CTU_FLAGS \
+    $ANALYZER_CONFIG_FLAG_1 $ANALYZER_CONFIG_FLAG_2
 EXIT_CODE=$?
 echo "::endgroup::"
 

--- a/src/execute-analysis.sh
+++ b/src/execute-analysis.sh
@@ -32,6 +32,12 @@ if [[ ! -z "$IN_ANALYZER_CONFIG" ]]; then
   ANALYZER_CONFIG_FLAG_2=$IN_ANALYZER_CONFIG
   echo "Using analyzer-config: \"$IN_ANALYZER_CONFIG\"!"
 fi
+
+if [[ ! -z "$IN_SKIPFILE" ]]; then
+  SKIPFILE_FLAG_1="--skip"
+  SKIPFILE_FLAG_2=$IN_SKIPFILE
+  echo "Using skipfile: \"$IN_SKIPFILE\"!"
+fi
 echo "::endgroup::"
 
 "$CODECHECKER_PATH"/CodeChecker analyzers \
@@ -45,7 +51,8 @@ echo "::group::Executing Static Analysis"
     --jobs $(nproc) \
     $CONFIG_FLAG_1 $CONFIG_FLAG_2 \
     $CTU_FLAGS \
-    $ANALYZER_CONFIG_FLAG_1 $ANALYZER_CONFIG_FLAG_2
+    $ANALYZER_CONFIG_FLAG_1 $ANALYZER_CONFIG_FLAG_2 \
+    $SKIPFILE_FLAG_1 $SKIPFILE_FLAG_2
 EXIT_CODE=$?
 echo "::endgroup::"
 

--- a/src/get-llvm.sh
+++ b/src/get-llvm.sh
@@ -7,8 +7,8 @@ set -u
 
 echo "::group::Installing LLVM"
 
-update-alternatives --query clang
-update-alternatives --query clang-tidy
+update-alternatives --query clang || echo "No clang installed. Continuing…"
+update-alternatives --query clang-tidy || echo "No clang-tidy installed. Continuing…"
 
 export DISTRO_FANCYNAME="$(lsb_release -c | awk '{ print $2 }')"
 curl -sL http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/src/store-pre.sh
+++ b/src/store-pre.sh
@@ -10,7 +10,7 @@ fi
 
 if [[ ! -z "$IN_STORE_USERNAME" && ! -z "$IN_STORE_PASSWORD" ]]; then
   echo "Configuring credentials..."
-  cat <<EOF > ~/.codechecker.passwords.json
+  cat <<EOF > /.codechecker.passwords.json
     {
       "client_autologin": true,
       "credentials": {
@@ -18,7 +18,7 @@ if [[ ! -z "$IN_STORE_USERNAME" && ! -z "$IN_STORE_PASSWORD" ]]; then
       }
     }
 EOF
-  chmod 0600 ~/.codechecker.passwords.json
+  chmod 0600 /.codechecker.passwords.json
 fi
 
 if [[ ! -z "$IN_STORE_RUN_NAME" && "$IN_STORE_RUN_NAME" != "__DEFAULT__" ]]; then

--- a/src/store.sh
+++ b/src/store.sh
@@ -35,6 +35,7 @@ if [[ ! -z "$CODECHECKER_STORE_RUN_TAG" ]]; then
   RUN_TAG_FLAG_1="--tag"
   RUN_TAG_FLAG_2=$CODECHECKER_STORE_RUN_TAG
 fi
+export CC_PASS_FILE=/.codechecker.passwords.json
 echo "::endgroup::"
 
 echo "::group::Storing results to server"


### PR DESCRIPTION
This PR fixes running CodeChecker-Action on custom containers with custom images and whatever other things I ran into while making it work.
Specifically:
- Updated the repository name in the README and fixed a typo there.
- Worked around some bugs in GitHub Actions' Runner software, like github.action_path being wrong and the home directory randomly changing.
- Fixed installing Clang without Clang.
- Allow specifying a skipfile and an analyzer-config.

I can of course split these changes into separate PRs if wanted.